### PR TITLE
[Issue #11] [Feature]: Expose a concise top-level run summary in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -68,6 +68,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.verificationSummary).toBe(
       "Verification completed and the run is ready for human review.",
     );
+    expect(payload.runSummary).toBe(payload.verificationSummary);
     expect(payload.verificationReport.decision).toBe(payload.verificationDecision);
     expect(payload.verificationReport.summary).toBe(payload.verificationSummary);
     expect(payload.autoMergePolicyEligible).toBe(true);
@@ -102,6 +103,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.mergedPullRequestMergedAt).toBeNull();
     expect(payload.verificationDecision).toBeNull();
     expect(payload.verificationSummary).toBeNull();
+    expect(payload.runSummary).toBe("Run is at the draft-pr-opened stage.");
     expect(payload.autoMergePolicyEligible).toBe(false);
     expect(payload.autoMergePolicyReason).toBe(
       "Not eligible for auto-merge: verification has not approved the run.",
@@ -130,6 +132,20 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.publishedPullRequestOpenedAt).toBeNull();
     expect(payload.pullRequestMerged).toBe(false);
     expect(payload.mergedPullRequestMergedAt).toBeNull();
+  });
+
+  it("falls back to the build summary when no verification summary exists", async () => {
+    mocks.runIssueWorkflow.mockResolvedValue(
+      createRun({
+        verificationReport: undefined,
+      }),
+    );
+
+    await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.verificationSummary).toBeNull();
+    expect(payload.runSummary).toBe("Updated JSON output");
   });
 
   it("blocks auto-merge when the build result is outside command-layer scope", async () => {

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -101,6 +101,18 @@ function resolveMergedPullRequest(run: WorkflowRun): {
   };
 }
 
+function resolveRunSummary(run: WorkflowRun): string {
+  if (run.verificationReport?.summary) {
+    return run.verificationReport.summary;
+  }
+
+  if (run.buildResult?.summary) {
+    return run.buildResult.summary;
+  }
+
+  return `Run is at the ${run.stage} stage.`;
+}
+
 function toWorkflowRunJson(run: WorkflowRun) {
   const autoMergePolicy = resolveAutoMergePolicy(run);
   const publishedPullRequest = resolvePublishedPullRequest(run);
@@ -120,6 +132,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     mergedPullRequestMergedAt: mergedPullRequest.mergedPullRequestMergedAt,
     verificationDecision: run.verificationReport?.decision ?? null,
     verificationSummary: run.verificationReport?.summary ?? null,
+    runSummary: resolveRunSummary(run),
     autoMergePolicyEligible: autoMergePolicy.autoMergePolicyEligible,
     autoMergePolicyReason: autoMergePolicy.autoMergePolicyReason,
   };


### PR DESCRIPTION
## Summary
Implement GitHub issue #11: [Feature]: Expose a concise top-level run summary in openclaw code run --json output

## Scope
[Feature]: Expose a concise top-level run summary in openclaw code run --json output.
### Summary.
Expose a concise top-level `runSummary` field in `openclaw code run --json` output.
### Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.