### PR TITLE
[Issue #13] [Feature]: Expose a human-readable stage label in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -44,6 +44,7 @@ describe("openclawCodeRunCommand", () => {
       "src/openclawcode/contracts/types.ts",
     ]);
     expect(payload.buildResult.changedFiles).toEqual(payload.changedFiles);
+    expect(payload.stageLabel).toBe("Ready For Human Review");
     expect(payload.issueClassification).toBe("command-layer");
     expect(payload.scopeCheck).toEqual({
       ok: true,
@@ -90,6 +91,7 @@ describe("openclawCodeRunCommand", () => {
 
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
     expect(payload.changedFiles).toEqual([]);
+    expect(payload.stageLabel).toBe("Draft Pr Opened");
     expect(payload.issueClassification).toBeNull();
     expect(payload.scopeCheck).toBeNull();
     expect(payload.draftPullRequestBranchName).toBeNull();

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import type { WorkflowRun } from "../openclawcode/index.js";
+import type { WorkflowRun, WorkflowStage } from "../openclawcode/index.js";
 import {
   FileSystemWorkflowRunStore,
   GitHubPullRequestMerger,
@@ -101,12 +101,20 @@ function resolveMergedPullRequest(run: WorkflowRun): {
   };
 }
 
+function formatWorkflowStageLabel(stage: WorkflowStage): string {
+  return stage
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 function toWorkflowRunJson(run: WorkflowRun) {
   const autoMergePolicy = resolveAutoMergePolicy(run);
   const publishedPullRequest = resolvePublishedPullRequest(run);
   const mergedPullRequest = resolveMergedPullRequest(run);
   return {
     ...run,
+    stageLabel: formatWorkflowStageLabel(run.stage),
     changedFiles: run.buildResult?.changedFiles ?? [],
     issueClassification: run.buildResult?.issueClassification ?? null,
     scopeCheck: run.buildResult?.scopeCheck ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #13: [Feature]: Expose a human-readable stage label in openclaw code run --json output

## Scope
[Feature]: Expose a human-readable stage label in openclaw code run --json output.
### Summary.
Expose a top-level `stageLabel` field in `openclaw code run --json` output.
### Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.