### PR TITLE
[Issue #13] [Feature]: Expose a human-readable stage label in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -39,6 +39,8 @@ describe("openclawCodeRunCommand", () => {
 
     expect(runtime.log).toHaveBeenCalledTimes(1);
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.stage).toBe("ready-for-human-review");
+    expect(payload.stageLabel).toBe("Ready For Human Review");
     expect(payload.changedFiles).toEqual([
       "src/openclawcode/app/run-issue.ts",
       "src/openclawcode/contracts/types.ts",
@@ -185,6 +187,7 @@ describe("openclawCodeRunCommand", () => {
     await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
 
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.stageLabel).toBe("Merged");
     expect(payload.pullRequestMerged).toBe(true);
     expect(payload.mergedPullRequestMergedAt).toBe("2026-01-02T03:04:05.000Z");
   });

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -90,6 +90,13 @@ function resolvePublishedPullRequest(run: WorkflowRun): {
   };
 }
 
+function formatWorkflowStageLabel(stage: WorkflowRun["stage"]): string {
+  return stage
+    .split("-")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
 function resolveMergedPullRequest(run: WorkflowRun): {
   pullRequestMerged: boolean;
   mergedPullRequestMergedAt: string | null;
@@ -107,6 +114,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
   const mergedPullRequest = resolveMergedPullRequest(run);
   return {
     ...run,
+    stageLabel: formatWorkflowStageLabel(run.stage),
     changedFiles: run.buildResult?.changedFiles ?? [],
     issueClassification: run.buildResult?.issueClassification ?? null,
     scopeCheck: run.buildResult?.scopeCheck ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #13: [Feature]: Expose a human-readable stage label in openclaw code run --json output

## Scope
[Feature]: Expose a human-readable stage label in openclaw code run --json output.
### Summary.
Expose a top-level `stageLabel` field in `openclaw code run --json` output.
### Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.