### PR TITLE
[Issue #17] [Feature]: Expose auto-merge disposition signals in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -244,6 +244,24 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.autoMergeDisposition).toBe("merged");
     expect(payload.autoMergeDispositionReason).toBe("Pull request merged automatically");
   });
+
+  it("leaves auto-merge disposition empty when the pr was merged without an auto-merge note", async () => {
+    mocks.runIssueWorkflow.mockResolvedValue(
+      createRun({
+        stage: "merged",
+        history: ["Pull request merged after manual approval"],
+        updatedAt: "2026-01-02T03:04:05.000Z",
+      }),
+    );
+
+    await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.pullRequestMerged).toBe(true);
+    expect(payload.mergedPullRequestMergedAt).toBe("2026-01-02T03:04:05.000Z");
+    expect(payload.autoMergeDisposition).toBeNull();
+    expect(payload.autoMergeDispositionReason).toBeNull();
+  });
 });
 
 function createRun(overrides: Partial<WorkflowRun> = {}): WorkflowRun {

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -92,10 +92,10 @@ function resolveAutoMergeDisposition(run: WorkflowRun): {
         entry.startsWith("Auto-merge failed:"),
     );
 
-  if (note === "Pull request merged automatically" || run.stage === "merged") {
+  if (note === "Pull request merged automatically") {
     return {
       autoMergeDisposition: "merged",
-      autoMergeDispositionReason: note ?? "Pull request merged automatically",
+      autoMergeDispositionReason: note,
     };
   }
 


### PR DESCRIPTION
## Summary
Implement GitHub issue #17: [Feature]: Expose auto-merge disposition signals in openclaw code run --json output

## Scope
[Feature]: Expose auto-merge disposition signals in openclaw code run --json output.
### Summary.
Expose stable auto-merge disposition signals in `openclaw code run --json` output.
### Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.