### PR TITLE
[Issue #25] [Feature]: Expose verification follow-up count in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -78,6 +78,7 @@ describe("openclawCodeRunCommand", () => {
     );
     expect(payload.verificationFindingCount).toBe(0);
     expect(payload.verificationMissingCoverageCount).toBe(0);
+    expect(payload.verificationFollowUpCount).toBe(0);
     expect(payload.runSummary).toBe(payload.verificationSummary);
     expect(payload.autoMergeDisposition).toBeNull();
     expect(payload.autoMergeDispositionReason).toBeNull();
@@ -122,6 +123,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.verificationSummary).toBeNull();
     expect(payload.verificationFindingCount).toBeNull();
     expect(payload.verificationMissingCoverageCount).toBeNull();
+    expect(payload.verificationFollowUpCount).toBeNull();
     expect(payload.runSummary).toBe("Run is at the draft-pr-opened stage.");
     expect(payload.autoMergeDisposition).toBeNull();
     expect(payload.autoMergeDispositionReason).toBeNull();
@@ -209,6 +211,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.verificationSummary).toBeNull();
     expect(payload.verificationFindingCount).toBeNull();
     expect(payload.verificationMissingCoverageCount).toBeNull();
+    expect(payload.verificationFollowUpCount).toBeNull();
     expect(payload.runSummary).toBe("Updated JSON output");
   });
 
@@ -270,7 +273,7 @@ describe("openclawCodeRunCommand", () => {
           summary: "Verification found blocking issues.",
           findings: ["Bug one", "Bug two"],
           missingCoverage: ["Missing test one"],
-          followUps: [],
+          followUps: ["Add regression coverage", "Fix the blocking bug"],
         },
       }),
     );
@@ -280,6 +283,7 @@ describe("openclawCodeRunCommand", () => {
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
     expect(payload.verificationFindingCount).toBe(2);
     expect(payload.verificationMissingCoverageCount).toBe(1);
+    expect(payload.verificationFollowUpCount).toBe(2);
   });
 
   it("prints failed auto-merge disposition when merge execution fails", async () => {

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -254,6 +254,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     verificationSummary: run.verificationReport?.summary ?? null,
     verificationFindingCount: run.verificationReport?.findings.length ?? null,
     verificationMissingCoverageCount: run.verificationReport?.missingCoverage.length ?? null,
+    verificationFollowUpCount: run.verificationReport?.followUps.length ?? null,
     runSummary: resolveRunSummary(run),
     autoMergeDisposition: autoMergeDisposition.autoMergeDisposition,
     autoMergeDispositionReason: autoMergeDisposition.autoMergeDispositionReason,


### PR DESCRIPTION
## Summary
Implement GitHub issue #25: [Feature]: Expose verification follow-up count in openclaw code run --json output

## Scope
[Feature]: Expose verification follow-up count in openclaw code run --json output.
### Summary.
Expose a stable top-level verification follow-up count in `openclaw code run --json` output.
### Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: mixed
Scope Check: Scope check passed for mixed issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.