### PR TITLE
[Issue #27] [Feature]: Expose verification approval status in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -73,6 +73,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.pullRequestMerged).toBe(false);
     expect(payload.mergedPullRequestMergedAt).toBeNull();
     expect(payload.verificationDecision).toBe("approve-for-human-review");
+    expect(payload.verificationApprovedForHumanReview).toBe(true);
     expect(payload.verificationSummary).toBe(
       "Verification completed and the run is ready for human review.",
     );
@@ -120,6 +121,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.pullRequestMerged).toBe(false);
     expect(payload.mergedPullRequestMergedAt).toBeNull();
     expect(payload.verificationDecision).toBeNull();
+    expect(payload.verificationApprovedForHumanReview).toBeNull();
     expect(payload.verificationSummary).toBeNull();
     expect(payload.verificationFindingCount).toBeNull();
     expect(payload.verificationMissingCoverageCount).toBeNull();
@@ -281,6 +283,7 @@ describe("openclawCodeRunCommand", () => {
     await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
 
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.verificationApprovedForHumanReview).toBe(false);
     expect(payload.verificationFindingCount).toBe(2);
     expect(payload.verificationMissingCoverageCount).toBe(1);
     expect(payload.verificationFollowUpCount).toBe(2);

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -224,6 +224,15 @@ function resolveRunSummary(run: WorkflowRun): string {
   return `Run is at the ${run.stage} stage.`;
 }
 
+function resolveVerificationApprovedForHumanReview(run: WorkflowRun): boolean | null {
+  const decision = run.verificationReport?.decision;
+  if (!decision) {
+    return null;
+  }
+
+  return decision === "approve-for-human-review";
+}
+
 function toWorkflowRunJson(run: WorkflowRun) {
   const autoMergePolicy = resolveAutoMergePolicy(run);
   const autoMergeDisposition = resolveAutoMergeDisposition(run);
@@ -251,6 +260,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     pullRequestMerged: mergedPullRequest.pullRequestMerged,
     mergedPullRequestMergedAt: mergedPullRequest.mergedPullRequestMergedAt,
     verificationDecision: run.verificationReport?.decision ?? null,
+    verificationApprovedForHumanReview: resolveVerificationApprovedForHumanReview(run),
     verificationSummary: run.verificationReport?.summary ?? null,
     verificationFindingCount: run.verificationReport?.findings.length ?? null,
     verificationMissingCoverageCount: run.verificationReport?.missingCoverage.length ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #27: [Feature]: Expose verification approval status in openclaw code run --json output

## Scope
[Feature]: Expose verification approval status in openclaw code run --json output.
### Summary.
Expose a stable top-level verification approval status in `openclaw code run --json` output.
### Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.