### PR TITLE
[Issue #30] [Feature]: Expose top-level scope check signals in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -54,6 +54,8 @@ describe("openclawCodeRunCommand", () => {
       blockedFiles: [],
       summary: "Scope check passed for command-layer issue.",
     });
+    expect(payload.scopeCheckPassed).toBe(true);
+    expect(payload.scopeBlockedFileCount).toBe(0);
     expect(payload.buildResult.issueClassification).toBe(payload.issueClassification);
     expect(payload.buildResult.scopeCheck).toEqual(payload.scopeCheck);
     expect(payload.draftPullRequestBranchName).toBe("openclawcode/issue-2");
@@ -110,6 +112,8 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.stageLabel).toBe("Draft PR Opened");
     expect(payload.issueClassification).toBeNull();
     expect(payload.scopeCheck).toBeNull();
+    expect(payload.scopeCheckPassed).toBeNull();
+    expect(payload.scopeBlockedFileCount).toBeNull();
     expect(payload.draftPullRequestBranchName).toBeNull();
     expect(payload.draftPullRequestBaseBranch).toBeNull();
     expect(payload.draftPullRequestNumber).toBeNull();

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -248,6 +248,8 @@ function toWorkflowRunJson(run: WorkflowRun) {
     changeDispositionReason: changeDisposition.changeDispositionReason,
     issueClassification: run.buildResult?.issueClassification ?? null,
     scopeCheck: run.buildResult?.scopeCheck ?? null,
+    scopeCheckPassed: run.buildResult?.scopeCheck?.ok ?? null,
+    scopeBlockedFileCount: run.buildResult?.scopeCheck?.blockedFiles.length ?? null,
     draftPullRequestBranchName: run.draftPullRequest?.branchName ?? null,
     draftPullRequestBaseBranch: run.draftPullRequest?.baseBranch ?? null,
     draftPullRequestNumber: run.draftPullRequest?.number ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #30: [Feature]: Expose top-level scope check signals in openclaw code run --json output

## Scope
[Feature]: Expose top-level scope check signals in openclaw code run --json output.
## Summary.
Add stable top-level scope check fields to `openclaw code run --json` output.
## Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.