### PR TITLE
[Issue #32] [Feature]: Expose top-level scope check summary in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -54,6 +54,7 @@ describe("openclawCodeRunCommand", () => {
       blockedFiles: [],
       summary: "Scope check passed for command-layer issue.",
     });
+    expect(payload.scopeCheckSummary).toBe("Scope check passed for command-layer issue.");
     expect(payload.scopeCheckPassed).toBe(true);
     expect(payload.scopeBlockedFileCount).toBe(0);
     expect(payload.buildResult.issueClassification).toBe(payload.issueClassification);
@@ -112,6 +113,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.stageLabel).toBe("Draft PR Opened");
     expect(payload.issueClassification).toBeNull();
     expect(payload.scopeCheck).toBeNull();
+    expect(payload.scopeCheckSummary).toBeNull();
     expect(payload.scopeCheckPassed).toBeNull();
     expect(payload.scopeBlockedFileCount).toBeNull();
     expect(payload.draftPullRequestBranchName).toBeNull();
@@ -265,6 +267,7 @@ describe("openclawCodeRunCommand", () => {
     await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
 
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.scopeCheckSummary).toBe("Scope check failed for command-layer issue.");
     expect(payload.scopeCheckPassed).toBe(false);
     expect(payload.scopeBlockedFileCount).toBe(1);
     expect(payload.autoMergePolicyEligible).toBe(false);

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -252,6 +252,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     changeDispositionReason: changeDisposition.changeDispositionReason,
     issueClassification: run.buildResult?.issueClassification ?? null,
     scopeCheck: run.buildResult?.scopeCheck ?? null,
+    scopeCheckSummary: run.buildResult?.scopeCheck?.summary ?? null,
     scopeCheckPassed: run.buildResult?.scopeCheck?.ok ?? null,
     scopeBlockedFileCount: run.buildResult?.scopeCheck?.blockedFiles.length ?? null,
     draftPullRequestBranchName: run.draftPullRequest?.branchName ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #32: [Feature]: Expose top-level scope check summary in openclaw code run --json output

## Scope
[Feature]: Expose top-level scope check summary in openclaw code run --json output.
## Summary.
Add a stable top-level `scopeCheckSummary` field to `openclaw code run --json` output.
## Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.