### PR TITLE
[Issue #34] [Feature]: Expose top-level scope blocked files in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -56,6 +56,7 @@ describe("openclawCodeRunCommand", () => {
     });
     expect(payload.scopeCheckSummary).toBe("Scope check passed for command-layer issue.");
     expect(payload.scopeCheckPassed).toBe(true);
+    expect(payload.scopeBlockedFiles).toEqual([]);
     expect(payload.scopeBlockedFileCount).toBe(0);
     expect(payload.buildResult.issueClassification).toBe(payload.issueClassification);
     expect(payload.buildResult.scopeCheck).toEqual(payload.scopeCheck);
@@ -115,6 +116,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.scopeCheck).toBeNull();
     expect(payload.scopeCheckSummary).toBeNull();
     expect(payload.scopeCheckPassed).toBeNull();
+    expect(payload.scopeBlockedFiles).toBeNull();
     expect(payload.scopeBlockedFileCount).toBeNull();
     expect(payload.draftPullRequestBranchName).toBeNull();
     expect(payload.draftPullRequestBaseBranch).toBeNull();
@@ -269,6 +271,7 @@ describe("openclawCodeRunCommand", () => {
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
     expect(payload.scopeCheckSummary).toBe("Scope check failed for command-layer issue.");
     expect(payload.scopeCheckPassed).toBe(false);
+    expect(payload.scopeBlockedFiles).toEqual(["src/openclawcode/orchestrator/run.ts"]);
     expect(payload.scopeBlockedFileCount).toBe(1);
     expect(payload.autoMergePolicyEligible).toBe(false);
     expect(payload.autoMergePolicyReason).toBe(

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -254,6 +254,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     scopeCheck: run.buildResult?.scopeCheck ?? null,
     scopeCheckSummary: run.buildResult?.scopeCheck?.summary ?? null,
     scopeCheckPassed: run.buildResult?.scopeCheck?.ok ?? null,
+    scopeBlockedFiles: run.buildResult?.scopeCheck?.blockedFiles ?? null,
     scopeBlockedFileCount: run.buildResult?.scopeCheck?.blockedFiles.length ?? null,
     draftPullRequestBranchName: run.draftPullRequest?.branchName ?? null,
     draftPullRequestBaseBranch: run.draftPullRequest?.baseBranch ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #34: [Feature]: Expose top-level scope blocked files in openclaw code run --json output

## Scope
[Feature]: Expose top-level scope blocked files in openclaw code run --json output.
## Summary.
Add a stable top-level `scopeBlockedFiles` field to `openclaw code run --json` output.
## Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.