### PR TITLE
[Issue #38] [Feature]: Document duplicate-delivery webhook handling in openclawcode README

### DIFF
--- a/docs/openclawcode/README.md
+++ b/docs/openclawcode/README.md
@@ -24,6 +24,7 @@ As of 2026-03-09, the repository includes a working `openclawcode` MVP slice wit
 
 - workflow state, persistence, and isolated worktree management
 - a GitHub-backed issue intake path
+- issue webhook redeliveries are deduplicated by `X-GitHub-Delivery`, so replaying the same delivery id does not create a second pending approval or queue entry; a fresh delivery for an issue that is already being tracked may still return `already-tracked`
 - a local builder/verifier runtime adapter built on top of OpenClaw's embedded agent entrypoint
 - a `openclaw code run ...` CLI path for issue-driven execution
 - draft PR publishing and optional merge hooks in the workflow service layer


### PR DESCRIPTION
## Summary
Implement GitHub issue #38: [Feature]: Document duplicate-delivery webhook handling in openclawcode README

## Scope
[Feature]: Document duplicate-delivery webhook handling in openclawcode README.
Summary.
Add a short operator-facing note in `docs/openclawcode/README.md` that explains repeated GitHub webhook deliveries are deduplicated by `X-GitHub-Delivery`.
Problem to solve.

## Changed Files
docs/openclawcode/README.md

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.