### PR TITLE
[Issue #41] [Docs]: Clarify that sync-hook rewrites the webhook secret in temporary ingress mode

### DIFF
--- a/docs/openclawcode/webhook-operations.md
+++ b/docs/openclawcode/webhook-operations.md
@@ -62,6 +62,11 @@ GitHub webhook:
 ./scripts/openclawcode-webhook-tunnel.sh sync-hook
 ```
 
+In this temporary-ingress flow, `sync-hook` rewrites the current quick-tunnel
+webhook URL and also re-applies `OPENCLAWCODE_GITHUB_WEBHOOK_SECRET` from
+`~/.openclaw/openclawcode.env` when that variable is present. That helps avoid
+GitHub deliveries failing with `401 Invalid signature` after a tunnel rotation.
+
 Restart the tunnel and resync the webhook:
 
 ```bash


### PR DESCRIPTION
## Summary
Implement GitHub issue #41: [Docs]: Clarify that sync-hook rewrites the webhook secret in temporary ingress mode

## Scope
[Docs]: Clarify that sync-hook rewrites the webhook secret in temporary ingress mode.
## Summary.
Document in `docs/openclawcode/webhook-operations.md` that `./scripts/openclawcode-webhook-tunnel.sh sync-hook` rewrites both the temporary public webhook URL and the configured GitHub webhook secret when `OPENCLAWCODE_GITHUB_WEBHOOK_SECRET` is available.
## Problem to solve.

## Changed Files
docs/openclawcode/webhook-operations.md

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.