### PR TITLE
[Issue #45] [Feature]: Add a no-rerun false assertion for rerunHasReviewContext in openclaw code run JSON

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -230,6 +230,24 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.rerunReviewUrl).toBeNull();
   });
 
+  it("reports false when rerun context is absent", async () => {
+    mocks.runIssueWorkflow.mockResolvedValue(
+      createRun({
+        rerunContext: undefined,
+      }),
+    );
+
+    await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.rerunRequested).toBe(false);
+    expect(payload.rerunHasReviewContext).toBe(false);
+    expect(payload.rerunReviewDecision).toBeNull();
+    expect(payload.rerunReviewSubmittedAt).toBeNull();
+    expect(payload.rerunReviewSummary).toBeNull();
+    expect(payload.rerunReviewUrl).toBeNull();
+  });
+
   it("keeps unpublished local draft metadata separate from published pr fields", async () => {
     mocks.runIssueWorkflow.mockResolvedValue(
       createRun({


### PR DESCRIPTION
## Summary
Implement GitHub issue #45: [Feature]: Add a no-rerun false assertion for rerunHasReviewContext in openclaw code run JSON

## Scope
[Feature]: Add a no-rerun false assertion for rerunHasReviewContext in openclaw code run JSON.
Summary.
Add one explicit unit-test assertion for the no-rerun case of `rerunHasReviewContext` in `openclaw code run --json`.
Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.