### PR TITLE
[Issue #36] [Feature]: Document /occode-sync in openclawcode README

### DIFF
--- a/docs/openclawcode/README.md
+++ b/docs/openclawcode/README.md
@@ -57,6 +57,9 @@ loop with:
   - aborts instead of continuing with a conflicted reusable branch refresh
 - a compact `/occode-inbox` operator ledger for recent lifecycle events, final
   disposition, rerun lineage, and last notification metadata
+- a manual `/occode-sync` recovery command that reconciles local run records
+  with tracked GitHub PR status when operators need to force a reconciliation
+  pass from chat
 - a repeatable operator setup runbook plus a repo-local setup verification
   script for gateway, webhook, binding, tunnel health, and required GitHub
   webhook event subscriptions


### PR DESCRIPTION
## Summary
Implement GitHub issue #36: [Feature]: Document /occode-sync in openclawcode README

## Scope
[Feature]: Document /occode-sync in openclawcode README.
Summary.
Add a short operator-facing note in `docs/openclawcode/README.md` that mentions the `/occode-sync` chat command.
Problem to solve.

## Changed Files
docs/openclawcode/README.md

## Implementation Scope
Classification: mixed
Scope Check: Scope check passed for mixed issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.