### PR TITLE
[Issue #48] [Feature]: Expose verificationHasFindings in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -81,6 +81,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.verificationSummary).toBe(
       "Verification completed and the run is ready for human review.",
     );
+    expect(payload.verificationHasFindings).toBe(false);
     expect(payload.verificationFindingCount).toBe(0);
     expect(payload.verificationMissingCoverageCount).toBe(0);
     expect(payload.verificationFollowUpCount).toBe(0);
@@ -131,6 +132,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.verificationDecision).toBeNull();
     expect(payload.verificationApprovedForHumanReview).toBeNull();
     expect(payload.verificationSummary).toBeNull();
+    expect(payload.verificationHasFindings).toBe(false);
     expect(payload.verificationFindingCount).toBeNull();
     expect(payload.verificationMissingCoverageCount).toBeNull();
     expect(payload.verificationFollowUpCount).toBeNull();
@@ -401,6 +403,7 @@ describe("openclawCodeRunCommand", () => {
 
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
     expect(payload.verificationApprovedForHumanReview).toBe(false);
+    expect(payload.verificationHasFindings).toBe(true);
     expect(payload.verificationFindingCount).toBe(2);
     expect(payload.verificationMissingCoverageCount).toBe(1);
     expect(payload.verificationFollowUpCount).toBe(2);

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -308,6 +308,8 @@ function toWorkflowRunJson(run: WorkflowRun) {
     verificationDecision: run.verificationReport?.decision ?? null,
     verificationApprovedForHumanReview: resolveVerificationApprovedForHumanReview(run),
     verificationSummary: run.verificationReport?.summary ?? null,
+    verificationHasFindings:
+      run.verificationReport == null ? false : run.verificationReport.findings.length > 0,
     verificationFindingCount: run.verificationReport?.findings.length ?? null,
     verificationMissingCoverageCount: run.verificationReport?.missingCoverage.length ?? null,
     verificationFollowUpCount: run.verificationReport?.followUps.length ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #48: [Feature]: Expose verificationHasFindings in openclaw code run --json output

## Scope
[Feature]: Expose verificationHasFindings in openclaw code run --json output.
Summary.
Add one stable top-level boolean field to `openclaw code run --json` named `verificationHasFindings`.
Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.