### PR TITLE
[Issue #51] [Feature]: Expose verificationHasFollowUps in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -82,6 +82,7 @@ describe("openclawCodeRunCommand", () => {
       "Verification completed and the run is ready for human review.",
     );
     expect(payload.verificationHasFindings).toBe(false);
+    expect(payload.verificationHasFollowUps).toBe(false);
     expect(payload.verificationFindingCount).toBe(0);
     expect(payload.verificationMissingCoverageCount).toBe(0);
     expect(payload.verificationFollowUpCount).toBe(0);
@@ -133,6 +134,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.verificationApprovedForHumanReview).toBeNull();
     expect(payload.verificationSummary).toBeNull();
     expect(payload.verificationHasFindings).toBe(false);
+    expect(payload.verificationHasFollowUps).toBe(false);
     expect(payload.verificationFindingCount).toBeNull();
     expect(payload.verificationMissingCoverageCount).toBeNull();
     expect(payload.verificationFollowUpCount).toBeNull();
@@ -143,6 +145,26 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.autoMergePolicyReason).toBe(
       "Not eligible for auto-merge: verification has not approved the run.",
     );
+  });
+
+  it("reports verificationHasFollowUps when verifier follow-up work exists", async () => {
+    mocks.runIssueWorkflow.mockResolvedValue(
+      createRun({
+        verificationReport: {
+          ...createRun().verificationReport!,
+          followUps: ["Add a regression test for the JSON follow-up flag."],
+        },
+      }),
+    );
+
+    await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.verificationHasFollowUps).toBe(true);
+    expect(payload.verificationFollowUpCount).toBe(1);
+    expect(payload.verificationReport.followUps).toEqual([
+      "Add a regression test for the JSON follow-up flag.",
+    ]);
   });
 
   it("forwards rerun flags into the workflow request and prints stable rerun JSON fields", async () => {

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -310,6 +310,8 @@ function toWorkflowRunJson(run: WorkflowRun) {
     verificationSummary: run.verificationReport?.summary ?? null,
     verificationHasFindings:
       run.verificationReport == null ? false : run.verificationReport.findings.length > 0,
+    verificationHasFollowUps:
+      run.verificationReport == null ? false : run.verificationReport.followUps.length > 0,
     verificationFindingCount: run.verificationReport?.findings.length ?? null,
     verificationMissingCoverageCount: run.verificationReport?.missingCoverage.length ?? null,
     verificationFollowUpCount: run.verificationReport?.followUps.length ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #51: [Feature]: Expose verificationHasFollowUps in openclaw code run --json output

## Scope
[Feature]: Expose verificationHasFollowUps in openclaw code run --json output.
Summary.
Add one stable top-level boolean field to `openclaw code run --json` named `verificationHasFollowUps`.
Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs

## Verification
Verification pending.