### PR TITLE
[Issue #56] [Feature]: Expose publishedPullRequestNumber in openclaw code run --json output

### DIFF
--- a/docs/openclawcode/dev-log/2026-03-12.md
+++ b/docs/openclawcode/dev-log/2026-03-12.md
@@ -706,3 +706,31 @@ Outcome:
   status surfaces
 - the next slice is no longer operator visibility; it is promoting this branch
   back to the long-lived `main` operator baseline and repeating the live proofs
+
+## Published PR Number Follow-Up
+
+Closed the verifier follow-up on issue `#56` by tightening how
+`openclaw code run --json` derives published PR metadata.
+
+Implementation:
+
+- kept `publishedPullRequestNumber` behind the same
+  `resolvePublishedPullRequest(...)` helper that already decides whether a PR is
+  actually published
+- documented the workflow invariant in code: the single persisted
+  `draftPullRequest` object becomes the published PR metadata source once
+  GitHub assigns a number or URL
+- added a regression in `src/commands/openclawcode.test.ts` for the case where
+  publication only records a URL, proving the top-level published number stays
+  `null` instead of guessing a value
+
+Validation:
+
+- `pnpm exec vitest run src/commands/openclawcode.test.ts --pool threads`
+- `pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads`
+- `pnpm build`
+
+Outcome:
+
+- `PR #57` now carries the verifier follow-up instead of leaving the field wired
+  straight to raw draft PR metadata

--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -317,6 +317,28 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.mergedPullRequestMergedAt).toBeNull();
   });
 
+  it("keeps published pull request number null when publication only records a url", async () => {
+    mocks.runIssueWorkflow.mockResolvedValue(
+      createRun({
+        draftPullRequest: {
+          ...createRun().draftPullRequest!,
+          number: undefined,
+          url: "https://github.com/openclaw/openclaw/pull/42",
+        },
+        history: ["Pull request opened: https://github.com/openclaw/openclaw/pull/42"],
+      }),
+    );
+
+    await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.draftPullRequestNumber).toBeNull();
+    expect(payload.draftPullRequestUrl).toBe("https://github.com/openclaw/openclaw/pull/42");
+    expect(payload.pullRequestPublished).toBe(true);
+    expect(payload.publishedPullRequestNumber).toBeNull();
+    expect(payload.publishedPullRequestOpenedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
   it("prints skipped draft pr disposition when publication is skipped for a no-op run", async () => {
     mocks.runIssueWorkflow.mockResolvedValue(
       createRun({

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -137,11 +137,15 @@ function resolveAutoMergeDisposition(run: WorkflowRun): {
 
 function resolvePublishedPullRequest(run: WorkflowRun): {
   pullRequestPublished: boolean;
+  publishedPullRequestNumber: number | null;
   publishedPullRequestOpenedAt: string | null;
 } {
+  // Workflow runs only persist one PR object. Once GitHub assigns a number or URL,
+  // that same draft metadata becomes the published PR source of truth.
   const published = run.draftPullRequest?.number != null || run.draftPullRequest?.url != null;
   return {
     pullRequestPublished: published,
+    publishedPullRequestNumber: published ? (run.draftPullRequest?.number ?? null) : null,
     publishedPullRequestOpenedAt: published ? (run.draftPullRequest?.openedAt ?? null) : null,
   };
 }
@@ -311,7 +315,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     draftPullRequestBranchName: run.draftPullRequest?.branchName ?? null,
     draftPullRequestBaseBranch: run.draftPullRequest?.baseBranch ?? null,
     draftPullRequestNumber: run.draftPullRequest?.number ?? null,
-    publishedPullRequestNumber: run.draftPullRequest?.number ?? null,
+    publishedPullRequestNumber: publishedPullRequest.publishedPullRequestNumber,
     draftPullRequestUrl: run.draftPullRequest?.url ?? null,
     draftPullRequestDisposition: draftPullRequestDisposition.draftPullRequestDisposition,
     draftPullRequestDispositionReason:


### PR DESCRIPTION
## Summary
Implement GitHub issue #56: [Feature]: Expose publishedPullRequestNumber in openclaw code run --json output

## Scope
[Feature]: Expose publishedPullRequestNumber in openclaw code run --json output.
Summary.
Add one stable top-level numeric field to `openclaw code run --json` named `publishedPullRequestNumber`.
Problem to solve.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Verification
Verification pending.