### PR TITLE
[Issue #65] [Feature]: Expose historyEntryCount in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -610,6 +610,35 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.verificationFollowUpCount).toBe(2);
   });
 
+  it("prints historyEntryCount when history is present", async () => {
+    mocks.runIssueWorkflow.mockResolvedValue(
+      createRun({
+        history: [
+          "Draft PR opened: https://github.com/openclaw/openclaw/pull/42",
+          "Verification approved for human review",
+        ],
+      }),
+    );
+
+    await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.historyEntryCount).toBe(2);
+  });
+
+  it("prints historyEntryCount as null when history is missing", async () => {
+    mocks.runIssueWorkflow.mockResolvedValue(
+      createRun({
+        history: undefined,
+      }),
+    );
+
+    await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.historyEntryCount).toBeNull();
+  });
+
   it("prints failed auto-merge disposition when merge execution fails", async () => {
     mocks.runIssueWorkflow.mockResolvedValue(
       createRun({

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -400,6 +400,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     verificationFindingCount: run.verificationReport?.findings.length ?? null,
     verificationMissingCoverageCount: run.verificationReport?.missingCoverage.length ?? null,
     verificationFollowUpCount: run.verificationReport?.followUps.length ?? null,
+    historyEntryCount: run.history?.length ?? null,
     rerunRequested: Boolean(run.rerunContext),
     rerunHasReviewContext,
     rerunReason: run.rerunContext?.reason ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #65: [Feature]: Expose historyEntryCount in openclaw code run --json output

## Scope
[Feature]: Expose historyEntryCount in openclaw code run --json output.
<!-- openclawcode-validation template=command-json-number class=command-layer -->.
Summary.
Add one stable top-level numeric field to `openclaw code run --json` named `historyEntryCount`.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Verification
Verification pending.