### PR TITLE
[Issue #68] [Feature]: Expose suitabilityReasonCount in openclaw code run --json output

### DIFF
--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -147,6 +147,7 @@ describe("openclawCodeRunCommand", () => {
       "Planner risk level is medium.",
       "No high-risk issue signals were detected in the issue text or labels.",
     ]);
+    expect(payload.suitabilityReasonCount).toBe(3);
     expect(payload.suitabilityClassification).toBe("command-layer");
     expect(payload.suitabilityRiskLevel).toBe("medium");
     expect(payload.suitabilityEvaluatedAt).toBe("2026-01-01T00:00:00.000Z");
@@ -222,6 +223,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.suitabilitySummary).toBe(
       "Suitability accepted for autonomous execution. Issue stays within command-layer scope.",
     );
+    expect(payload.suitabilityReasonCount).toBe(3);
     expect(payload.draftPullRequestBranchName).toBeNull();
     expect(payload.draftPullRequestBaseBranch).toBeNull();
     expect(payload.draftPullRequestNumber).toBeNull();
@@ -250,6 +252,20 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.autoMergePolicyReason).toBe(
       "Not eligible for auto-merge: verification has not approved the run.",
     );
+  });
+
+  it("prints null suitabilityReasonCount when suitability metadata is unavailable", async () => {
+    mocks.runIssueWorkflow.mockResolvedValue(
+      createRun({
+        suitability: undefined,
+      }),
+    );
+
+    await openclawCodeRunCommand({ issue: "2", repoRoot: "/repo", json: true }, runtime);
+
+    const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
+    expect(payload.suitabilityReasons).toBeNull();
+    expect(payload.suitabilityReasonCount).toBeNull();
   });
 
   it("prints null attempt counts when workflow attempt metadata is unavailable", async () => {

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -367,6 +367,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     suitabilityDecision: run.suitability?.decision ?? null,
     suitabilitySummary: run.suitability?.summary ?? null,
     suitabilityReasons: run.suitability?.reasons ?? null,
+    suitabilityReasonCount: run.suitability?.reasons.length ?? null,
     suitabilityClassification: run.suitability?.classification ?? null,
     suitabilityRiskLevel: run.suitability?.riskLevel ?? null,
     suitabilityEvaluatedAt: run.suitability?.evaluatedAt ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #68: [Feature]: Expose suitabilityReasonCount in openclaw code run --json output

## Scope
[Feature]: Expose suitabilityReasonCount in openclaw code run --json output.
<!-- openclawcode-validation template=command-json-number class=command-layer -->.
Summary.
Add one stable top-level numeric field to `openclaw code run --json` named `suitabilityReasonCount`.

## Changed Files
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Verification
Verification pending.