### PR TITLE
[Issue #89] [Feature]: Expose failureDiagnosticToolCount in openclaw code run --json output

### DIFF
--- a/docs/openclawcode/run-json-contract.md
+++ b/docs/openclawcode/run-json-contract.md
@@ -79,6 +79,7 @@ those nested objects.
 
 - `failureDiagnostics`
 - `failureDiagnosticsSummary`
+- `failureDiagnosticToolCount`
 
 ### Suitability Signals
 
@@ -152,6 +153,7 @@ those nested objects.
 ## Nullability Rules
 
 - count fields use `null` when the underlying metadata does not exist
+- derived count fields such as `failureDiagnosticToolCount` mirror documented nested metadata when present and otherwise use `null`
 - boolean summary fields such as `verificationHasFindings` default to `false`
   when the corresponding section is absent
 - string or timestamp fields use `null` when the underlying value is absent

--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -856,6 +856,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.historyEntryCount).toBeNull();
     expect(payload.failureDiagnostics).toBeNull();
     expect(payload.failureDiagnosticsSummary).toBeNull();
+    expect(payload.failureDiagnosticToolCount).toBeNull();
   });
 
   it("prints failure diagnostics when a failed workflow recorded provider metadata", async () => {
@@ -899,6 +900,7 @@ describe("openclawCodeRunCommand", () => {
       bootstrapWarningShown: false,
       lastCallUsageTotal: 0,
     });
+    expect(payload.failureDiagnosticToolCount).toBe(4);
   });
 
   it("prints failed auto-merge disposition when merge execution fails", async () => {

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -406,6 +406,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     noteCount: run.buildResult?.notes.length ?? null,
     failureDiagnostics: run.failureDiagnostics ?? null,
     failureDiagnosticsSummary: run.failureDiagnostics?.summary ?? null,
+    failureDiagnosticToolCount: run.failureDiagnostics?.toolCount ?? null,
     suitabilityDecision: run.suitability?.decision ?? null,
     suitabilitySummary: run.suitability?.summary ?? null,
     suitabilityReasons: run.suitability?.reasons ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #89: [Feature]: Expose failureDiagnosticToolCount in openclaw code run --json output

## Scope
[Feature]: Expose failureDiagnosticToolCount in openclaw code run --json output.
<!-- openclawcode-validation template=command-json-number class=command-layer -->.
Summary.
Add one stable top-level numeric field to `openclaw code run --json` named `failureDiagnosticToolCount`.

## Changed Files
docs/openclawcode/run-json-contract.md
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Verification
Verification pending.