### PR TITLE
[Issue #91] [Feature]: Expose failureDiagnosticUsageTotal in openclaw code run --json output

### DIFF
--- a/docs/openclawcode/run-json-contract.md
+++ b/docs/openclawcode/run-json-contract.md
@@ -79,6 +79,7 @@ those nested objects.
 
 - `failureDiagnostics`
 - `failureDiagnosticsSummary`
+- `failureDiagnosticUsageTotal`
 
 ### Suitability Signals
 

--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -856,6 +856,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.historyEntryCount).toBeNull();
     expect(payload.failureDiagnostics).toBeNull();
     expect(payload.failureDiagnosticsSummary).toBeNull();
+    expect(payload.failureDiagnosticUsageTotal).toBeNull();
   });
 
   it("prints failure diagnostics when a failed workflow recorded provider metadata", async () => {
@@ -886,6 +887,7 @@ describe("openclawCodeRunCommand", () => {
 
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
     expect(payload.failureDiagnosticsSummary).toBe("HTTP 400: Internal server error");
+    expect(payload.failureDiagnosticUsageTotal).toBe(0);
     expect(payload.failureDiagnostics).toEqual({
       summary: "HTTP 400: Internal server error",
       provider: "crs",

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -406,6 +406,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     noteCount: run.buildResult?.notes.length ?? null,
     failureDiagnostics: run.failureDiagnostics ?? null,
     failureDiagnosticsSummary: run.failureDiagnostics?.summary ?? null,
+    failureDiagnosticUsageTotal: run.failureDiagnostics?.lastCallUsageTotal ?? null,
     suitabilityDecision: run.suitability?.decision ?? null,
     suitabilitySummary: run.suitability?.summary ?? null,
     suitabilityReasons: run.suitability?.reasons ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #91: [Feature]: Expose failureDiagnosticUsageTotal in openclaw code run --json output

## Scope
[Feature]: Expose failureDiagnosticUsageTotal in openclaw code run --json output.
<!-- openclawcode-validation template=command-json-number class=command-layer -->.
Summary.
Add one stable top-level numeric field to `openclaw code run --json` named `failureDiagnosticUsageTotal`.

## Changed Files
docs/openclawcode/run-json-contract.md
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Verification
Verification pending.