### PR TITLE
[Issue #93] [Feature]: Expose failureDiagnosticSystemPromptChars in openclaw code run --json output

### DIFF
--- a/docs/openclawcode/README.md
+++ b/docs/openclawcode/README.md
@@ -50,6 +50,7 @@ loop with:
   saved run artifacts and the top-level JSON contract as:
   - `failureDiagnostics`
   - `failureDiagnosticsSummary`
+  - `failureDiagnosticSystemPromptChars`
 - draft PR publishing and guarded merge hooks in the workflow service layer
 - event-driven `pull_request` / `pull_request_review` webhook intake with chat
   notifications for tracked lifecycle changes

--- a/docs/openclawcode/run-json-contract.md
+++ b/docs/openclawcode/run-json-contract.md
@@ -79,6 +79,7 @@ those nested objects.
 
 - `failureDiagnostics`
 - `failureDiagnosticsSummary`
+- `failureDiagnosticSystemPromptChars`
 - `failureDiagnosticToolCount`
 
 ### Suitability Signals
@@ -153,7 +154,7 @@ those nested objects.
 ## Nullability Rules
 
 - count fields use `null` when the underlying metadata does not exist
-- derived count fields such as `failureDiagnosticToolCount` mirror documented nested metadata when present and otherwise use `null`
+- derived numeric fields such as `failureDiagnosticSystemPromptChars` and `failureDiagnosticToolCount` mirror documented nested metadata when present and otherwise use `null`
 - boolean summary fields such as `verificationHasFindings` default to `false`
   when the corresponding section is absent
 - string or timestamp fields use `null` when the underlying value is absent

--- a/src/commands/openclawcode.test.ts
+++ b/src/commands/openclawcode.test.ts
@@ -863,6 +863,7 @@ describe("openclawCodeRunCommand", () => {
     expect(payload.historyEntryCount).toBeNull();
     expect(payload.failureDiagnostics).toBeNull();
     expect(payload.failureDiagnosticsSummary).toBeNull();
+    expect(payload.failureDiagnosticSystemPromptChars).toBeNull();
     expect(payload.failureDiagnosticToolCount).toBeNull();
   });
 
@@ -894,6 +895,7 @@ describe("openclawCodeRunCommand", () => {
 
     const payload = JSON.parse(runtime.log.mock.calls[0]?.[0] ?? "null");
     expect(payload.failureDiagnosticsSummary).toBe("HTTP 400: Internal server error");
+    expect(payload.failureDiagnosticSystemPromptChars).toBe(8629);
     expect(payload.failureDiagnosticToolCount).toBe(4);
     expect(payload.failureDiagnostics).toEqual({
       summary: "HTTP 400: Internal server error",

--- a/src/commands/openclawcode.ts
+++ b/src/commands/openclawcode.ts
@@ -536,6 +536,7 @@ function toWorkflowRunJson(run: WorkflowRun) {
     noteCount: run.buildResult?.notes.length ?? null,
     failureDiagnostics: run.failureDiagnostics ?? null,
     failureDiagnosticsSummary: run.failureDiagnostics?.summary ?? null,
+    failureDiagnosticSystemPromptChars: run.failureDiagnostics?.systemPromptChars ?? null,
     failureDiagnosticToolCount: run.failureDiagnostics?.toolCount ?? null,
     suitabilityDecision: run.suitability?.decision ?? null,
     suitabilitySummary: run.suitability?.summary ?? null,


### PR DESCRIPTION
## Summary
Implement GitHub issue #93: [Feature]: Expose failureDiagnosticSystemPromptChars in openclaw code run --json output

## Scope
[Feature]: Expose failureDiagnosticSystemPromptChars in openclaw code run --json output.
<!-- openclawcode-validation template=command-json-number class=command-layer -->.
Summary.
Add one stable top-level numeric field to `openclaw code run --json` named `failureDiagnosticSystemPromptChars`.

## Changed Files
docs/openclawcode/README.md
docs/openclawcode/run-json-contract.md
src/commands/openclawcode.test.ts
src/commands/openclawcode.ts

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests
pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Test Results
PASS pnpm exec vitest run --config vitest.openclawcode.config.mjs --pool threads

## Verification
Verification pending.