### PR TITLE
[Issue #87] [Docs]: Clarify where provider pauses are visible for queued work

### DIFF
--- a/docs/openclawcode/operator-setup.md
+++ b/docs/openclawcode/operator-setup.md
@@ -440,6 +440,8 @@ After the health check passes:
 3. verify the chat receives the approval prompt or auto-start notification
 4. run `/occode-start <owner>/<repo>#<issue>` if the repo is in approve mode
 5. confirm `/occode-inbox` shows the issue moving through queued or running state
+   - if intake succeeded but the work stays queued behind an active provider
+     pause, check `/occode-inbox` for the queue entry and `/occode-status <owner>/<repo>#<issue>` for the issue-level status; both chat-visible surfaces render the active provider-pause context for queued work
 
 You can also validate the explicit chat-side intake path directly from the
 bound conversation:


### PR DESCRIPTION
## Summary
Implement GitHub issue #87: [Docs]: Clarify where provider pauses are visible for queued work

## Scope
[Docs]: Clarify where provider pauses are visible for queued work.
<!-- openclawcode-validation template=operator-doc-note class=operator-docs -->.
Summary.
Clarify where operators can see provider-pause state when work is already queued.

## Changed Files
docs/openclawcode/operator-setup.md

## Implementation Scope
Classification: command-layer
Scope Check: Scope check passed for command-layer issue.

## Acceptance Criteria
- [ ] The implementation addresses the GitHub issue directly and stays within scope.
- [ ] Repository checks selected for the run complete successfully.

## Tests

## Test Results

## Verification
Verification pending.